### PR TITLE
Fixing issues with updates to ember-cli-fastboot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
 env:
   # we recommend new addons test the current and previous LTS
   # as well as latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=ember-lts-2.12
+  - EMBER_TRY_SCENARIO=ember-2.15
   - EMBER_TRY_SCENARIO=ember-2.16
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,24 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  # we recommend testing addons with the same minimum supported node version as Ember CLI
+  # so that your addon works for all apps
+  - "4"
 
 sudo: false
+dist: trusty
+
+addons:
+  chrome: stable
 
 cache:
-  directories:
-    - $HOME/.npm
+  yarn: true
 
 env:
-  # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=ember-lts-2.4
+  # we recommend new addons test the current and previous LTS
+  # as well as latest stable release (bonus points to beta/canary)
   - EMBER_TRY_SCENARIO=ember-lts-2.8
+  - EMBER_TRY_SCENARIO=ember-lts-2.12
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
@@ -24,14 +30,13 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - npm config set spin false
-  - npm install -g phantomjs-prebuilt
-  - phantomjs --version
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
 
 install:
-  - npm install
+  - yarn install --no-lockfile --non-interactive
 
 script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
-  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: false
 dist: trusty
@@ -17,8 +17,8 @@ cache:
 env:
   # we recommend new addons test the current and previous LTS
   # as well as latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=ember-lts-2.8
-  - EMBER_TRY_SCENARIO=ember-lts-2.12
+  - EMBER_TRY_SCENARIO=ember-lts-2.13
+  - EMBER_TRY_SCENARIO=ember-lts-2.14
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ cache:
 env:
   # we recommend new addons test the current and previous LTS
   # as well as latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=ember-lts-2.13
-  - EMBER_TRY_SCENARIO=ember-lts-2.14
+  - EMBER_TRY_SCENARIO=ember-lts-2.12
+  - EMBER_TRY_SCENARIO=ember-2.16
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ember-cli-prerender
 
-An Ember CLI addon for prerendering Ember.js apps and generating sitemaps. 
+An Ember CLI addon for prerendering Ember.js apps and generating sitemaps.
 
 ## The problem
 
@@ -19,7 +19,7 @@ When a Javascript application is prerendered, the intial render on the client-si
 You should definitely use this addon if:
 
 - **SEO matters.** You want to bring in organic traffic from search engines as much as possible.
-- **UX matters.** You want your pages to render as fast as possible. 
+- **UX matters.** You want your pages to render as fast as possible.
 - **Social Media matters.** When you or other people share your content, you want to be able to customize what image, title and description is displayed on social media.
 - **Content changes are always followed by a build.** As the prerendering with this addon happens on build time, you should NOT use it if your content changes without running a build. An example would be an app displaying frequently changing content from an API.
 - **Not much personalization.** Most of your pages are not personalized and are showing the same content to all visitors.
@@ -37,7 +37,7 @@ You should definitely use this addon if:
     - The initial load time will be much faster and this will improve the user experience significantly while giving your Ember app a SEO boost.
     - It's compatible with [ember-cli-head](https://github.com/ronco/ember-cli-head), so you can set title, description and meta tags per route for social media and search engine crawler bots ([Example](tests/dummy/app/routes/user.js)).
 - The prerendering is really quick, because it happens asynchronously with throttling to minimize the prerendering time.
-- You can exclude specific pages from being listed on the sitemap ([How](tests/dummy/app/utils/sitemap-entry-filter.js)). This is useful for hiding private routes, for example. 
+- You can exclude specific pages from being listed on the sitemap ([How](tests/dummy/app/utils/sitemap-entry-filter.js)). This is useful for hiding private routes, for example.
 - Follows the [standard protocol](https://www.sitemaps.org/protocol.html) for XML sitemaps. `<loc>` tag is automatically added to the XML sitemap for each page. `<lastmod>`, `<changefreq>` and `<priority>` can be added as well ([Example](tests/dummy/app/utils/sitemap-entry-filter.js)).
 - Compatible with the newest version of Ember (2.13).
 - Compatible with the pod-based structure.
@@ -69,7 +69,7 @@ Are you using this addon in production as well? Edit [README.md](README.md) and 
 
 - `ember install ember-cli-prerender`
 - `ember generate sitemap-utils`
-- `ember generate sitemap xml` (optional, for submitting to search engines) 
+- `ember generate sitemap xml` (optional, for submitting to search engines)
 - `ember generate sitemap txt` (required for the prerendering functionality to work)  
 - If you're using [dynamic segments](https://guides.emberjs.com/v2.13.0/routing/defining-your-routes/#toc_dynamic-segments), edit `utils/dynamic-segment-resolver.js` so that it returns possible values for each dynamic segment ([Example](tests/dummy/app/utils/dynamic-segment-resolver.js)).
 - Configure the addon in your `ember-cli-build.js`:
@@ -79,7 +79,7 @@ Are you using this addon in production as well? Edit [README.md](README.md) and 
       sitemap: {
 
         /**
-         * Your Ember app's internet address. 
+         * Your Ember app's internet address.
          * All relative paths in your sitemap will be prefixed with this.
          */
         rootUrl: 'https://mydummyapp.com/',
@@ -135,13 +135,13 @@ You most likely will not need to adjust any of the following settings.
 
 Setting | Type | Default | Description
 --- | --- | --- | ---
-keep-fastboot | Boolean | false | If set to false, it will remove the `/dist/fastboot` folder, because you do not need it in production.
 input-dir | String | dist | Change it if your app does not get built in the default `/dist` directory.
 output-dir | String | dist | By default, the prerendered files are saved in your `/dist` folder. This option allows you to change that.
 empty-output-dir | Boolean | false | If true, the prerendering script will clear the output directory before creating the prerendered files. Should be used in conjunction with `output-dir`.
 max-simultaneous-url-fetches | Number | 4 | We throttle requests to our local Fastboot server so it doesn't get overloaded with too many async requests.
 root-url | String |  | You can leave it blank if your app is located at the root-level on your domain. If your app is in a subfolder, this setting should match the `rootUrl` setting in your `ember-cli-build.js`.
 sitemap-file-name | String | sitemap | The file name for the txt and xml sitemaps.
+use-alternative-server | String | false | If you want to bypass using the prerender server and use one of your own
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This addon uses FastBoot when prerendering your app, but it uses it on buildtime
 
 This addon is being used in production in the following websites:
 
-- [MicroMech](https://micromech.net) (The new version that uses this addon is scheduled to launch to the public in a few weeks)
+- [MicroMech](https://micromech.net)
 - [Declan Ramsay Portfolio](https://declanramsay.co.uk)
 
 Are you using this addon in production as well? Edit [README.md](README.md) and add your site to this list!

--- a/blueprints/sitemap-utils/files/app/utils/dynamic-segment-resolver.js
+++ b/blueprints/sitemap-utils/files/app/utils/dynamic-segment-resolver.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-unused-vars
+/* eslint-disable */
 export default function dynamicSegmentResolver(dynamicSegmentKey, allSegments, otherDynamicSegments) {
 
   /**

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,22 +2,6 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-lts-2.4',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#lts-2-4'
-        },
-        resolutions: {
-          'ember': 'lts-2-4'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
       name: 'ember-lts-2.8',
       bower: {
         dependencies: {
@@ -30,6 +14,14 @@ module.exports = {
       npm: {
         devDependencies: {
           'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-lts-2.12',
+      npm: {
+        devDependencies: {
+          'ember-source': '~2.12.0'
         }
       }
     },

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,18 +2,10 @@
 module.exports = {
   scenarios: [
     {
-      name: 'ember-lts-2.8',
-      bower: {
-        dependencies: {
-          'ember': 'components/ember#lts-2-8'
-        },
-        resolutions: {
-          'ember': 'lts-2-8'
-        }
-      },
+      name: 'ember-2.16',
       npm: {
         devDependencies: {
-          'ember-source': null
+          'ember-source': '~2.16.0'
         }
       }
     },
@@ -21,7 +13,7 @@ module.exports = {
       name: 'ember-lts-2.12',
       npm: {
         devDependencies: {
-          'ember-source': '~2.12.0'
+          'ember-source': '~2.12.3'
         }
       }
     },

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -10,10 +10,10 @@ module.exports = {
       }
     },
     {
-      name: 'ember-lts-2.12',
+      name: 'ember-2.15',
       npm: {
         devDependencies: {
-          'ember-source': '~2.12.0'
+          'ember-source': '~2.15.0'
         }
       }
     },

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -13,7 +13,7 @@ module.exports = {
       name: 'ember-lts-2.12',
       npm: {
         devDependencies: {
-          'ember-source': '~2.12.3'
+          'ember-source': '~2.12.0'
         }
       }
     },

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = {
    */
   includedCommands: function() {
     return {
-      'prerender': require('./lib/commands/prerender'),
+      'prerender': require('./lib/commands/prerender')
     };
   },
 };

--- a/lib/tasks/prerender.js
+++ b/lib/tasks/prerender.js
@@ -6,13 +6,13 @@ const throat = require('throat');
 
 module.exports = (userOptions, project) => {
   const options = Object.assign({
-    keepFastboot: false,
     inputDir: 'dist',
     outputDir: 'dist',
     emptyOutputDir: false,
     maxSimultaneousUrlFetches: 4,
     rootUrl: '',
     sitemapFileName: 'sitemap',
+    useAlternativeServer:false
   }, userOptions);
 
   /**
@@ -32,8 +32,12 @@ module.exports = (userOptions, project) => {
   /**
    * Instantiate the Fastboot server
    */
-  const localServer = new FastBootAppServer({ distPath: pathJoin(options.inputDir) });
-  const localServerUrl = 'http://localhost:3000';
+  const localServer = new FastBootAppServer({
+    distPath: pathJoin(options.inputDir),
+    host:'0.0.0.0',
+    port:3000
+   });
+  const localServerUrl = useAlternativeServer?useAlternativeServer:'http://localhost:3000';
 
   /**
    * Function for fetching URLs from the local server
@@ -69,6 +73,7 @@ module.exports = (userOptions, project) => {
       pathJoin(options.outputDir, path) :
       pathJoin(options.outputDir, path, 'index.html');
 
+    console.log("Saving : "+localPath);
     return fs.outputFile(localPath, body);
   };
 
@@ -82,9 +87,6 @@ module.exports = (userOptions, project) => {
      */
     if (!fs.pathExistsSync(pathJoin(options.inputDir))) {
       throw new Error(`The input directory '${options.inputDir}' does not exist.`);
-    }
-    if (!fs.pathExistsSync(pathJoin(options.inputDir, '/fastboot'))) {
-      throw new Error(`The input directory '${userFriendlyPath(options.inputDir, '/fastboot')}' does not exist.`);
     }
     if (!fs.pathExistsSync(pathJoin(options.inputDir, 'index.html'))) {
       throw new Error(`'${userFriendlyPath(options.inputDir, 'index.html')}' does not exist.`);
@@ -160,7 +162,7 @@ module.exports = (userOptions, project) => {
               return saveFile(`${localServerUrl}/${options.sitemapFileName}.txt`, found[1])
                 .then(() => urls);
             })
-        )
+
         /**
          * Fetch all pages
          */
@@ -191,25 +193,18 @@ module.exports = (userOptions, project) => {
             )
           )
         )
-        /**
-         * Remove the fastboot directory, because we do not need it in production.
-         */
-        .then(() => {
-          if (!options.keepFastboot) {
-            return fs.remove(pathJoin(options.inputDir, '/fastboot'));
-          }
-        })
+
         /**
          * Catch errors
          */
         .catch((err) => {
-          console.log('Error occured', err);
+          console.log('Error occured - Aborting Prerendering', err);
           localServer.stop();
         })
         /**
          * Print how long prerendering took
          */
-        .then(() => console.log(`Prerendering took ${Date.now() - startedAt}ms`));
+        .then(() => console.log(`Prerendering took ${Date.now() - startedAt}ms`)));
     }
 
     return new Promise(resolve => {}); // Workers should return an unresolved promise

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "static-server": "static-server dist"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.0.0",
-    "ember-cli-fastboot": "1.0.0-beta.19",
+    "ember-cli-babel": "^6.3.0",
+    "ember-cli-fastboot": "^1.1.0",
     "ember-cli-htmlbars": "2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.4.0",
     "fastboot-app-server": "^1.0.0-rc.5",
@@ -36,25 +36,29 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
-    "ember-cli": "2.13.2",
+    "ember-cli": "~2.15.1",
     "ember-cli-code-coverage": "^0.3.12",
-    "ember-cli-dependency-checker": "2.0.0",
-    "ember-cli-eslint": "^3.0.0",
+    "ember-cli-dependency-checker": "^2.0.0",
+    "ember-cli-eslint": "^4.0.0",
     "ember-cli-head": "^0.2.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-disable-prototype-extensions": "^1.1.0",
+    "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-network": "^0.3.1",
     "ember-resolver": "^4.0.0",
-    "ember-source": "2.13.2",
+    "ember-source": "~2.15.0",
+    "ember-welcome-page": "^3.0.0",
     "express-simple-static-server": "^0.1.0",
     "loader.js": "^4.2.3",
     "phantomjs-prebuilt": "^2.1.14"
+  },
+  "peerDependencies": {
+    "ember-cli-fastboot": "^1.2.0"
   },
   "engines": {
     "node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-prerender",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "An Ember CLI addon for prerendering Ember.js apps.",
   "keywords": [
     "ember-addon"
@@ -24,13 +24,11 @@
     "static-server": "static-server dist"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.3.0",
-    "ember-cli-fastboot": "^1.1.0",
+    "ember-cli-babel": "^6.8.2",
     "ember-cli-htmlbars": "2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.4.0",
-    "fastboot-app-server": "^1.0.0-rc.5",
-    "fs-extra": "3.0.1",
-    "node-fetch": "1.7.0",
+    "fs-extra": "^3.0.1",
+    "node-fetch": "1.7.3",
     "throat": "^3.0.0"
   },
   "devDependencies": {
@@ -54,11 +52,9 @@
     "ember-source": "~2.15.0",
     "ember-welcome-page": "^3.0.0",
     "express-simple-static-server": "^0.1.0",
+    "fastboot-app-server": "^1.1.0",
     "loader.js": "^4.2.3",
     "phantomjs-prebuilt": "^2.1.14"
-  },
-  "peerDependencies": {
-    "ember-cli-fastboot": "^1.2.0"
   },
   "engines": {
     "node": ">= 6"

--- a/testem.js
+++ b/testem.js
@@ -1,12 +1,19 @@
 /* eslint-env node */
 module.exports = {
-  "test_page": "tests/index.html?hidepassed",
-  "disable_watching": true,
-  "launch_in_ci": [
-    "PhantomJS"
+  test_page: 'tests/index.html?hidepassed',
+  disable_watching: true,
+  launch_in_ci: [
+    'Chrome'
   ],
-  "launch_in_dev": [
-    "PhantomJS",
-    "Chrome"
-  ]
+  launch_in_dev: [
+    'Chrome'
+  ],
+  browser_args: {
+    Chrome: [
+      '--disable-gpu',
+      '--headless',
+      '--remote-debugging-port=9222',
+      '--window-size=1440,900'
+    ]
+  }
 };

--- a/tests/dummy/app/utils/dynamic-segment-resolver.js
+++ b/tests/dummy/app/utils/dynamic-segment-resolver.js
@@ -1,6 +1,6 @@
 import fetch from 'ember-network/fetch';
 
-// eslint-disable-next-line no-unused-vars
+/* eslint-disable */
 export default function dynamicSegmentResolver(dynamicSegmentKey, allSegments, otherDynamicSegments) {
 
   /**

--- a/tests/dummy/app/utils/sitemap-entry-filter.js
+++ b/tests/dummy/app/utils/sitemap-entry-filter.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line no-unused-vars
+/* eslint-disable */
 export default function sitemapEntryFilter(entry, segments, dynamicSegments) {
 
   /**

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 
-const { RSVP: { Promise } } = Ember;
+const { RSVP: { resolve } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {
@@ -17,7 +17,7 @@ export default function(name, options = {}) {
 
     afterEach() {
       let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
-      return Promise.resolve(afterEach).then(() => destroyApp(this.application));
+      return resolve(afterEach).then(() => destroyApp(this.application));
     }
   });
 }


### PR DESCRIPTION
There's still some issues locally with the build in server for serving the files for prerendering, but added an option to run the server externally as a temporary stopgap.